### PR TITLE
Added support for secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,9 @@ module "iam" {
 
   # In case Fargate is enabled an extra role needs to be added
   fargate_enabled = "${var.fargate_enabled}"
+
+  # The container uses secrets and needs a task execution role to get access to them
+  has_secrets = "${length(keys(var.container_secrets)) > 0}"
 }
 
 #
@@ -184,6 +187,7 @@ module "container_definition" {
   hostname = "${var.awsvpc_enabled == 1 ? "" : var.name}"
 
   container_envvars = "${var.container_envvars}"
+  container_secrets = "${var.container_secrets}"
 
   container_docker_labels = "${var.container_docker_labels}"
 

--- a/modules/ecs_container_definition/main.tf
+++ b/modules/ecs_container_definition/main.tf
@@ -17,6 +17,15 @@ resource "null_resource" "envvars_as_list_of_maps" {
   )}"
 }
 
+resource "null_resource" "secrets_as_list_of_maps" {
+  count = "${length(keys(var.container_secrets))}"
+
+  triggers = "${map(
+    "name", "${local.safe_search_replace_string}${element(keys(var.container_secrets), count.index)}",
+    "valueFrom", "${local.safe_search_replace_string}${element(values(var.container_secrets), count.index)}",
+  )}"
+}
+
 locals {
   port_mappings = {
     with_port = [
@@ -48,6 +57,7 @@ locals {
 
     hostname     = "${var.hostname}"
     environment  = ["${null_resource.envvars_as_list_of_maps.*.triggers}"]
+    secrets      = ["${null_resource.secrets_as_list_of_maps.*.triggers}"]
     mountPoints  = ["${var.mountpoints}"]
     portMappings = "${local.port_mappings[local.use_port]}"
     healthCheck  = "${var.healthcheck}"

--- a/modules/ecs_container_definition/variables.tf
+++ b/modules/ecs_container_definition/variables.tf
@@ -75,6 +75,16 @@ variable "container_envvars" {
   default     = {}
 }
 
+variable "container_secrets" {
+  description = <<EOF
+    The environment variables to pass to the container as SSM keys. 
+    The keys will be looked up and the resulting values will be passed to the environment variable.
+    This is a map
+  EOF
+
+  default = {}
+}
+
 variable "readonly_root_filesystem" {
   description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value."
   default     = "false"

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -20,14 +20,14 @@ data "aws_iam_policy_document" "ecs_task_assume_role" {
 
 # The ECS TASK ROLE execution role needed for FARGATE & AWS LOGS
 resource "aws_iam_role" "ecs_task_execution_role" {
-  count              = "${(var.create && var.fargate_enabled ) ? 1 : 0 }"
+  count              = "${(var.create && (var.fargate_enabled || var.has_secrets) ) ? 1 : 0 }"
   name               = "${var.name}-ecs-task-execution_role"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_task_assume_role.json}"
 }
 
-# We need this for FARGATE
+# We need this for tasks with an execution role, e.g. those using Fargate or SSM secrets
 resource "aws_iam_role_policy_attachment" "ecs_tasks_execution_role" {
-  count      = "${(var.create && var.fargate_enabled ) ? 1 : 0 }"
+  count      = "${(var.create && (var.fargate_enabled || var.has_secrets) ) ? 1 : 0 }"
   role       = "${aws_iam_role.ecs_task_execution_role.id}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy" "kms_permissions" {
 
 # Policy Document to allow access to SSM Parameter Store paths
 data "aws_iam_policy_document" "ssm_permissions" {
-  count = "${var.create && var.ssm_enabled ? 1 : 0 }"
+  count = "${var.create && (var.ssm_enabled || var.has_secrets) ? 1 : 0 }"
 
   ## Add Describe Parameters as per https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
   statement {
@@ -89,6 +89,14 @@ resource "aws_iam_role_policy" "ssm_permissions" {
   count  = "${(var.create && var.ssm_enabled) ? 1 : 0 }"
   name   = "${var.name}-ssm-permissions"
   role   = "${aws_iam_role.ecs_tasks_role.id}"
+  policy = "${data.aws_iam_policy_document.ssm_permissions.json}"
+}
+
+# Add the SSM policy to the task execution role
+resource "aws_iam_role_policy" "ssm_permissions_execution" {
+  count  = "${(var.create && var.has_secrets) ? 1 : 0 }"
+  name   = "${var.name}-ssm-permissions-exution-role"
+  role   = "${aws_iam_role.ecs_task_execution_role.id}"
   policy = "${data.aws_iam_policy_document.ssm_permissions.json}"
 }
 

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -16,6 +16,11 @@ variable "fargate_enabled" {
   default = false
 }
 
+variable "has_secrets" {
+  description = "true, if the container needs access to SSM secrets"
+  default     = false
+}
+
 # Whether to provide access to the supplied kms_keys. If no kms keys are
 # passed, set this to false.
 variable "kms_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -309,6 +309,16 @@ container_envvars defines extra container env vars, list of maps:
   default = {}
 }
 
+variable "container_secrets" {
+  description = <<EOF
+    The environment variables to pass to the container as SSM keys. 
+    The keys will be looked up and the resulting values will be passed to the environment variable.
+    This is a map
+  EOF
+
+  default = {}
+}
+
 variable "name" {
   description = "The name of the project, must be unique"
 }


### PR DESCRIPTION
The module now supports an extra parameter `container_secrets`, similar to
`container_envvars`.

Values in this map will be treated as SSM keys and the actual value
injected into the environment of the container will be pulled from SSM.
To work, the SSM keys must also be added to `ssm_paths`.

Example:

```
container_secrets = {
  DB_PASSWORD = "myapp/dev/db.password"
}
ssm_paths         = ["myapp/dev"]
```

The example above injects the (decrypted) contents of
`/myapp/dev/db.password` into the env. variable `DB_PASSWORD`.